### PR TITLE
Scaffold auth endpoints and services (#41)

### DIFF
--- a/timesheet-api/Auth/Models/AuthDtos.cs
+++ b/timesheet-api/Auth/Models/AuthDtos.cs
@@ -1,0 +1,9 @@
+namespace timesheet_api.Auth.Models;
+
+public record LoginRequest(string Identifier, string Password, bool? RememberMe, string? CorrelationId);
+
+public record LogoutRequest(Guid UserId, string? SessionId);
+
+public record PasswordResetRequest(string Email);
+
+public record PasswordResetConfirmRequest(string Token, string NewPassword, string ConfirmPassword);

--- a/timesheet-api/Auth/Services/AuthService.cs
+++ b/timesheet-api/Auth/Services/AuthService.cs
@@ -1,0 +1,16 @@
+namespace timesheet_api.Auth.Services;
+
+public class AuthService : IAuthService
+{
+    public Task AuthenticateAsync(string identifier, string password, bool rememberMe, string ip, string userAgent)
+    {
+        // TODO: Implement ASP.NET Core Identity integration per issue #41
+        return Task.CompletedTask;
+    }
+
+    public Task SignOutAsync(Guid userId, string sessionId)
+    {
+        // TODO: Invalidate user session(s) per issue #41
+        return Task.CompletedTask;
+    }
+}

--- a/timesheet-api/Auth/Services/IAuthService.cs
+++ b/timesheet-api/Auth/Services/IAuthService.cs
@@ -1,0 +1,7 @@
+namespace timesheet_api.Auth.Services;
+
+public interface IAuthService
+{
+    Task AuthenticateAsync(string identifier, string password, bool rememberMe, string ip, string userAgent);
+    Task SignOutAsync(Guid userId, string sessionId);
+}

--- a/timesheet-api/Auth/Services/IPasswordResetService.cs
+++ b/timesheet-api/Auth/Services/IPasswordResetService.cs
@@ -1,0 +1,7 @@
+namespace timesheet_api.Auth.Services;
+
+public interface IPasswordResetService
+{
+    Task RequestResetAsync(string email, string ip, string userAgent);
+    Task ConfirmResetAsync(string token, string newPassword);
+}

--- a/timesheet-api/Auth/Services/PasswordResetService.cs
+++ b/timesheet-api/Auth/Services/PasswordResetService.cs
@@ -1,0 +1,16 @@
+namespace timesheet_api.Auth.Services;
+
+public class PasswordResetService : IPasswordResetService
+{
+    public Task RequestResetAsync(string email, string ip, string userAgent)
+    {
+        // TODO: Generate token and enqueue email per issue #41
+        return Task.CompletedTask;
+    }
+
+    public Task ConfirmResetAsync(string token, string newPassword)
+    {
+        // TODO: Validate token and update password per issue #41
+        return Task.CompletedTask;
+    }
+}

--- a/timesheet-api/Program.cs
+++ b/timesheet-api/Program.cs
@@ -1,8 +1,15 @@
+using timesheet_api.Auth.Models;
+using timesheet_api.Auth.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+
+builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IPasswordResetService, PasswordResetService>();
 
 var app = builder.Build();
 
@@ -18,6 +25,42 @@ var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
+
+app.MapPost("/api/auth/login", async (LoginRequest request, IAuthService auth, HttpContext ctx) =>
+{
+    var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "";
+    var userAgent = ctx.Request.Headers["User-Agent"].ToString();
+    await auth.AuthenticateAsync(request.Identifier, request.Password, request.RememberMe ?? false, ip, userAgent);
+    return Results.Ok(new
+    {
+        message = "Login endpoint scaffolded",
+        sessionExpiresAt = DateTimeOffset.UtcNow.AddHours(8)
+    });
+})
+.WithName("AuthLogin");
+
+app.MapPost("/api/auth/logout", async (LogoutRequest request, IAuthService auth) =>
+{
+    await auth.SignOutAsync(request.UserId, request.SessionId ?? string.Empty);
+    return Results.Ok(new { message = "Logout endpoint scaffolded" });
+})
+.WithName("AuthLogout");
+
+app.MapPost("/api/auth/password-reset/request", async (PasswordResetRequest request, IPasswordResetService svc, HttpContext ctx) =>
+{
+    var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "";
+    var userAgent = ctx.Request.Headers["User-Agent"].ToString();
+    await svc.RequestResetAsync(request.Email, ip, userAgent);
+    return Results.Ok(new { message = "If the account exists, a reset link will be sent." });
+})
+.WithName("PasswordResetRequest");
+
+app.MapPost("/api/auth/password-reset/confirm", async (PasswordResetConfirmRequest request, IPasswordResetService svc) =>
+{
+    await svc.ConfirmResetAsync(request.Token, request.NewPassword);
+    return Results.Ok(new { message = "Password reset confirmation scaffolded" });
+})
+.WithName("PasswordResetConfirm");
 
 app.MapGet("/weatherforecast", () =>
 {


### PR DESCRIPTION
This PR scaffolds minimal authentication API endpoints and service interfaces to address issue #41.

Summary:
- Added minimal API endpoints:
  - POST /api/auth/login
  - POST /api/auth/logout
  - POST /api/auth/password-reset/request
  - POST /api/auth/password-reset/confirm
- Introduced DTOs for request payloads.
- Added service interfaces `IAuthService` and `IPasswordResetService` with placeholder implementations wired via DI.
- Kept existing minimal API style to align with current project structure.

Notes:
- Implementations are placeholders; no persistence or identity wiring yet. Follow-ups will integrate ASP.NET Core Identity (with Argon2id/bcrypt), rate limiting, email dispatch worker, and audit logging as outlined in #41.

Closes: #41 (scaffold phase)